### PR TITLE
Added condition to include qscintilla release or debug library

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -72,7 +72,8 @@ win32 {
     TARGET = ../bin/kuzya
     LIBS += -L../3rdparty/QScintilla/2.9.4
     INCLUDEPATH = ../3rdparty/QScintilla/2.9.4
-    LIBS += -lqscintilla2
+   CONFIG(debug, debug|release):LIBS += -lqscintilla2d
+    else:                        LIBS += -lqscintilla2
 }
 
 mac {
@@ -80,3 +81,4 @@ mac {
     DESTDIR +=../kuzya
     TARGET +=kuzya
 }
+

--- a/src/src.pro
+++ b/src/src.pro
@@ -72,8 +72,8 @@ win32 {
     TARGET = ../bin/kuzya
     LIBS += -L../3rdparty/QScintilla/2.9.4
     INCLUDEPATH = ../3rdparty/QScintilla/2.9.4
-   CONFIG(debug, debug|release):LIBS += -lqscintilla2d
-    else:                        LIBS += -lqscintilla2
+    CONFIG(debug, debug|release):LIBS += -lqscintilla2d
+    else: LIBS += -lqscintilla2
 }
 
 mac {


### PR DESCRIPTION
This branch must be merged only after feature/15-debug-library have been merged in submodule - src.pro will include qscintilla2d.lib.