### PR TITLE
Bugfix/25 broken connection

### DIFF
--- a/src/kuzya.cpp
+++ b/src/kuzya.cpp
@@ -260,7 +260,8 @@ Kuzya::Kuzya(QWidget *parent)
 
     connect(textEditor,	SIGNAL(modificationChanged(bool)), this,SLOT(slotModificationChanged(bool)));
 
-    connect(fileDialog, SIGNAL(filterSelected(QString)), this,      SLOT(slotSetFileSuffix(QString)));
+    connect(fileDialog, SIGNAL(filterSelected(QString)), this,      SLOT(slotSetFileSuffix(QStringList)));
+                    /* implicit cast QString to QStrinList by QStringList(const QString &str) constucrtor */
 
     statusBar()->showMessage(tr("Ready"));
 

--- a/src/kuzya.cpp
+++ b/src/kuzya.cpp
@@ -260,8 +260,7 @@ Kuzya::Kuzya(QWidget *parent)
 
     connect(textEditor,	SIGNAL(modificationChanged(bool)), this,SLOT(slotModificationChanged(bool)));
 
-    connect(fileDialog, SIGNAL(filterSelected(QString)), this,      SLOT(slotSetFileSuffix(QStringList)));
-                    /* implicit cast QString to QStrinList by QStringList(const QString &str) constucrtor */
+    connect(fileDialog, SIGNAL(filterSelected(QString)), this,      SLOT(slotSetFileSuffix(QString)));
 
     statusBar()->showMessage(tr("Ready"));
 
@@ -658,6 +657,11 @@ void Kuzya::slotSetFileSuffix(QStringList filter)
     if (filter.count() > 0) {
         fileDialog->setDefaultSuffix(filter.at(0));
     }
+}
+
+void Kuzya::slotSetFileSuffix(QString suffix)
+{   //this methods explicitly converts QString to QstrinList. Using by singals/slot connection
+    slotSetFileSuffix(static_cast<QStringList>(suffix));
 }
 
 void Kuzya::setUndoRedoEnabled()

--- a/src/kuzya.cpp
+++ b/src/kuzya.cpp
@@ -260,7 +260,10 @@ Kuzya::Kuzya(QWidget *parent)
 
     connect(textEditor,	SIGNAL(modificationChanged(bool)), this,SLOT(slotModificationChanged(bool)));
 
-    connect(fileDialog, SIGNAL(filterSelected(QString)), this,      SLOT(slotSetFileSuffix(QString)));
+    connect(fileDialog, &QFileDialog::fileSelected, this, [this](const QString& suffix)
+    {
+        slotSetFileSuffix(QStringList() << suffix);
+    });
 
     statusBar()->showMessage(tr("Ready"));
 
@@ -657,11 +660,6 @@ void Kuzya::slotSetFileSuffix(QStringList filter)
     if (filter.count() > 0) {
         fileDialog->setDefaultSuffix(filter.at(0));
     }
-}
-
-void Kuzya::slotSetFileSuffix(QString suffix)
-{   //this methods explicitly converts QString to QstrinList. Using by singals/slot connection
-    slotSetFileSuffix(static_cast<QStringList>(suffix));
 }
 
 void Kuzya::setUndoRedoEnabled()

--- a/src/kuzya.h
+++ b/src/kuzya.h
@@ -142,7 +142,6 @@ private slots:
         void slotModificationChanged(bool);
 
         void slotSetFileSuffix(QStringList);
-        void slotSetFileSuffix(QString suffix);
 
         void setUndoRedoEnabled();
 

--- a/src/kuzya.h
+++ b/src/kuzya.h
@@ -142,6 +142,7 @@ private slots:
         void slotModificationChanged(bool);
 
         void slotSetFileSuffix(QStringList);
+        void slotSetFileSuffix(QString suffix);
 
         void setUndoRedoEnabled();
 


### PR DESCRIPTION
Added overloading of void slotSetFileSuffix method in Kuzya class with Qstring parameter. It convert Qstring to Qstring list. Broken signal/slot connection will use it and convert Qstring to QstringList successfully.