### PR TITLE
Gdb/46 - set breakpoints

### DIFF
--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -216,7 +216,7 @@ void Compiler::loadProfile(QString lang, QString profile)
     if (QString::Null() == profPath) return;
 
     compilerProfile = new QSettings(profPath, QSettings::IniFormat);
-    compileMode = DEFAULT;
+//    compileMode = DEFAULT;
 }
 
 void Compiler::setOptions(QString str)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -321,6 +321,9 @@ QString Compiler::getCompilerParams()
     case DYNAMIC_LIB:
         param = compilerProfile->value("dynamic_lib","").toString();
         break;
+    case DEBUG:
+        param = compilerProfile->value("debug", "").toString();
+        break;
     default:
         param = "";
     }

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -32,7 +32,7 @@ class Compiler : public QProcess
 	Q_OBJECT
 public:
         enum endStatusEnum{STATUS_NOERROR, STATUS_ERROR, STATUS_FAILED_TO_START, STATUS_CRASHED};
-        enum compileModeEnum{DEFAULT, ALTERNATIVE, OBJECT, STATIC_LIB, DYNAMIC_LIB};
+        enum compileModeEnum{DEFAULT, ALTERNATIVE, OBJECT, STATIC_LIB, DYNAMIC_LIB, DEBUG};
 
 	struct compilerError
 	{

--- a/src/kuzya.cpp
+++ b/src/kuzya.cpp
@@ -1151,7 +1151,7 @@ void Kuzya::slotUpdateWindowName(bool m)
 **/
 void Kuzya::slotMarginClicked(int margin, int line, Qt::KeyboardModifiers modifier)
 {
-    if(modifier == Qt::KeyboardModifier::AltModifier && line+1 < textEditor->lines())
+    if(modifier == Qt::KeyboardModifier::AltModifier)
     { // breakpoints section
         int bitMask = textEditor->markersAtLine(line);
         if(bitMask & 1<<3)  //1<<3 = 0x4 - mask for breakpoint margin

--- a/src/kuzya.cpp
+++ b/src/kuzya.cpp
@@ -686,6 +686,7 @@ void Kuzya::setUndoRedoEnabled()
 
 void Kuzya::slotRunDebugMode()
 {
+    compiler->setCompilerMode(Compiler::DEBUG);
     if(recompile())
     {
         try

--- a/src/kuzya.cpp
+++ b/src/kuzya.cpp
@@ -285,15 +285,10 @@ Kuzya::Kuzya(QWidget *parent)
     textEditorShortcut->setKey(Qt::CTRL+Qt::Key_Up);
     connect(textEditorShortcut, SIGNAL(activated()), textEditor, SLOT(setFocus()));
 
-//    if (qApp->argc() > 1)
-//    {
-//        this->openFile(qApp->argv()[qApp->argc()-1]);
-//    }
     QString comp = settings->readDefaultCompiler(language);
     QString compDir = settings->readCompilerLocation(language, comp);
     QString gdbDir = tr("%1\\%2").arg(compDir).arg("bin\\gdb.exe");
     mGdbDebugger = new Gdb(gdbDir);
-    mGdbDebugger->start();
 
 #ifdef Q_OS_MAC
     setAllIconsVisibleInMenu(false);
@@ -691,6 +686,10 @@ void Kuzya::slotRunDebugMode()
     {
         try
         {
+            if(mGdbDebugger->state() == QProcess::NotRunning)
+            {
+                mGdbDebugger->start();
+            }
             mGdbDebugger->stopExecuting();
             mGdbDebugger->waitForReadyRead(3000);
             QString programPath = compiler->getProgramPath();

--- a/src/kuzya.cpp
+++ b/src/kuzya.cpp
@@ -634,7 +634,7 @@ void Kuzya::slotOpen(void)
 void Kuzya::refreshCompileModes()
 {
     actionDefaultMode->setChecked(true);
-    compiler->setCompilerMode(Compiler::DEFAULT);
+//    compiler->setCompilerMode(Compiler::DEFAULT);
     actionAlternativeMode->setVisible(compiler->isModeAvailable(Compiler::ALTERNATIVE));
     actionObjectMode->setVisible(compiler->isModeAvailable(Compiler::OBJECT));
     actionStaticLibMode->setVisible(compiler->isModeAvailable(Compiler::STATIC_LIB));
@@ -682,6 +682,12 @@ void Kuzya::setUndoRedoEnabled()
 void Kuzya::slotRunDebugMode()
 {
     compiler->setCompilerMode(Compiler::DEBUG);
+    if(!srcRecompiled)
+    {
+        addNotification(NTYPE_WAIT, "Terminating program...");
+        mGdbDebugger->stopExecuting();
+        mGdbDebugger->waitForReadyRead();
+    }
     if(recompile())
     {
         try
@@ -690,7 +696,6 @@ void Kuzya::slotRunDebugMode()
             {
                 mGdbDebugger->start();
             }
-            mGdbDebugger->stopExecuting();
             mGdbDebugger->waitForReadyRead(3000);
             QString programPath = compiler->getProgramPath();
             QString fullProgramPath = tr("%1.exe").arg(programPath);
@@ -705,6 +710,7 @@ void Kuzya::slotRunDebugMode()
                 if(breakpoinLine != -1)
                 { // BE CAREFULL! set breakpoints to -1 may cause undefined behaviour, breakpoints may be everywhere
                     mGdbDebugger->setBreakPoint(breakpoinLine+1);
+                    mGdbDebugger->waitForReadyRead();
                 }
             }
             while(breakpoinLine != -1);

--- a/src/kuzya.cpp
+++ b/src/kuzya.cpp
@@ -1145,7 +1145,7 @@ void Kuzya::slotUpdateWindowName(bool m)
 **/
 void Kuzya::slotMarginClicked(int margin, int line, Qt::KeyboardModifiers modifier)
 {
-    if(modifier == Qt::KeyboardModifier::AltModifier)
+    if(modifier == Qt::KeyboardModifier::AltModifier && line+1 < textEditor->lines())
     { // breakpoints section
         int bitMask = textEditor->markersAtLine(line);
         if(bitMask & 1<<3)  //1<<3 = 0x4 - mask for breakpoint margin

--- a/src/kuzya.cpp
+++ b/src/kuzya.cpp
@@ -696,12 +696,8 @@ void Kuzya::slotRunDebugMode()
             QString fullProgramPath = tr("%1.exe").arg(programPath);
             fullProgramPath = fullProgramPath.replace("\\", "/");
             mGdbDebugger->openProject(fullProgramPath);
-            mGdbDebugger->globalUpdate();   //update to get relevant breakpoints
-            auto oldBreakpoints = mGdbDebugger->getBreakpoints();
-            for(Breakpoint i : oldBreakpoints)
-            { // remove all breakpoints from gdb
-                mGdbDebugger->clearBreakPoint(i.getLine());
-            }
+            mGdbDebugger->write(QByteArray("delete")); //remove all breakpoints
+            mGdbDebugger->waitForReadyRead();
             int breakpoinLine = 0;
             do
             { // set new breakpoints


### PR DESCRIPTION
I've implemented opportunity to set\clear breakpoint internally in GDB via clicking on the left side of text editor. 

Before running we should recompile program definitely. Thats why we should set breapoints internally in gdb right after compiling, but before running. After resetting new recompiled program in gdb we have all old breakpoints, so, we should remove them off. Than we need to set relevant breakpoints. Before compiling all new breakpoints are storing in textEditor's (markers).