### PR TITLE
Gdb/95 toggle breakpoint while debugging

### DIFF
--- a/src/kuzya.cpp
+++ b/src/kuzya.cpp
@@ -730,19 +730,7 @@ void Kuzya::slotRunDebugMode()
             QString fullProgramPath = tr("%1.exe").arg(programPath);
             fullProgramPath = fullProgramPath.replace("\\", "/");
             mGdbDebugger->openProject(fullProgramPath);
-//                mGdbDebugger->write(QByteArray("delete")); //remove all breakpoints
-//                mGdbDebugger->waitForReadyRead();
-//                int breakpoinLine = 0;
-//                do
-//                { // set new breakpoints
-//                    breakpoinLine = textEditor->markerFindNext(breakpoinLine+1, BREAKPOINT_MARK);
-//                    if(breakpoinLine != -1)
-//                    { // BE CAREFULL! set breakpoints to -1 may cause undefined behaviour, breakpoints may be everywhere
-//                        mGdbDebugger->setBreakPoint(breakpoinLine+1);
-//                        mGdbDebugger->waitForReadyRead();
-//                    }
-//                }
-//                while(breakpoinLine != -1);
+
             updateBreakpoints();
 
             mGdbDebugger->run();

--- a/src/kuzya.h
+++ b/src/kuzya.h
@@ -113,6 +113,7 @@ public:
         void refreshProfileSettings();
         void LoadTemplates(QString);
         void updateDebugger(const QString& debuggerLocation);
+        void updateBreakpoints();
 
 protected:
 
@@ -227,6 +228,7 @@ private:
         QToolBar *toolBar;
         Gdb* mGdbDebugger;
         WatchWindow* debugTab;
+        bool mDebugMode;
 };
 
 #endif


### PR DESCRIPTION
I have extracted method updateBreakpoints() from slotRunInDebugMode() (Kuzya class). This method is using by slotMarginClicked(), slotRunInDebugMode() to set/clear breakpoints in gdb while debugging.